### PR TITLE
adding radiation acceleration to transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(Geant4 11.1 REQUIRED gdml)
 add_executable(qtnmSim
   qtnmSim.cc
   src/QTDetectorConstruction.cc
+  src/QTBorisScheme.cc
+  src/QTBorisDriver.cc
   src/QTFieldMessenger.cc
   src/QTMagneticFieldSetup.cc
   src/QTRunAction.cc

--- a/include/QTBorisDriver.hh
+++ b/include/QTBorisDriver.hh
@@ -1,0 +1,192 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// from G4BorisDriver
+//
+// Class description:
+//
+//   G4BorisDriver is a driver class using the second order Boris 
+// method to integrate the equation of motion.
+// 
+//
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun 
+// --------------------------------------------------------------------
+#ifndef QTBORIS_DRIVER_HH
+#define QTBORIS_DRIVER_HH
+
+#include "G4VIntegrationDriver.hh"
+#include "QTBorisScheme.hh"
+#include "G4ChordFinderDelegate.hh"
+
+
+class QTBorisDriver : public G4VIntegrationDriver,
+                      public G4ChordFinderDelegate<QTBorisDriver>
+{
+  public:
+
+    QTBorisDriver( G4double hminimum,
+                   QTBorisScheme* Boris,
+                   G4int numberOfComponents = 6,
+                   G4bool verbosity = false);
+   
+    inline ~QTBorisDriver() override = default;
+
+    inline QTBorisDriver(const QTBorisDriver&) = delete;
+    inline QTBorisDriver& operator=(const QTBorisDriver&) = delete;
+
+    // 1. Core methods that advance the integration
+
+    G4bool AccurateAdvance( G4FieldTrack& track,
+                            G4double stepLen,
+                            G4double epsilon,
+                            G4double beginStep = 0) override;
+      // Advance integration accurately
+      // - by relative accuracy better than 'epsilon'
+
+    G4bool QuickAdvance(       G4FieldTrack& y_val,   // In/Out
+                         const G4double dydx[],    
+                               G4double       hstep,
+                               G4double&   missDist,  // Out: estimated sagitta
+                               G4double&   dyerr   ) override;
+      // Attempt one integration step, and return estimated error 'dyerr'
+
+    void OneGoodStep(G4double  yCurrentState[],  // In/Out: state ('y')
+                     G4double& curveLength,      // In/Out: 'x'
+                     G4double  htry,             // step to attempt
+                     G4double  epsilon_rel,      // relative accuracy
+                     G4double  restMass,         
+                     G4double  charge,
+                     G4double& hdid,             // Out: step achieved
+                     G4double& hnext);           // Out: proposed next step
+      // Method to implement Accurate Advance
+   
+    // 2. Methods needed to co-work with G4ChordFinder
+
+    G4double AdvanceChordLimited(G4FieldTrack& track,
+                                 G4double hstep,
+                                 G4double eps,
+                                 G4double chordDistance) override
+    {
+      return ChordFinderDelegate::
+             AdvanceChordLimitedImpl(track, hstep, eps, chordDistance);
+    }
+
+    void OnStartTracking() override
+    {
+      ChordFinderDelegate::ResetStepEstimate();
+    }
+
+    void OnComputeStep(const G4FieldTrack*) override {}
+
+    // 3. Does the method redo integrations when called to obtain values for
+    //    internal, smaller intervals? (when needed to identify an intersection)
+
+    G4bool DoesReIntegrate() const override { return true; }
+      // It would be no if it just used interpolation to provide a result.
+
+    // 4. Relevant for calculating a new step size to achieve required accuracy
+
+    inline G4double ComputeNewStepSize(G4double  errMaxNorm, // normalised error
+                                       G4double  hstepCurrent) override; // current step size
+
+    G4double ShrinkStepSize2(G4double h, G4double error2) const;
+    G4double GrowStepSize2(G4double h, G4double error2) const;
+      // Calculate the next step size given the square of the relative error
+   
+    // 5. Auxiliary Methods ...
+
+    void GetDerivatives( const G4FieldTrack& track,
+                               G4double dydx[] ) const override;
+
+    void GetDerivatives( const G4FieldTrack& track,
+                               G4double dydx[],
+                               G4double field[] ) const override;
+
+    inline void SetVerboseLevel(G4int level) override;
+    inline G4int GetVerboseLevel() const override;
+
+    inline G4EquationOfMotion* GetEquationOfMotion() override;
+    inline const G4EquationOfMotion* GetEquationOfMotion() const;
+    void SetEquationOfMotion(G4EquationOfMotion* equation) override;
+
+    void  StreamInfo( std::ostream& os ) const override;
+     // Write out the parameters / state of the driver
+   
+    // 6. Not relevant for Boris and other non-RK methods
+
+    inline const G4MagIntegratorStepper* GetStepper() const override;
+    inline G4MagIntegratorStepper* GetStepper() override;
+
+  private:
+
+    inline G4int GetNumberOfVariables() const;
+
+    inline void CheckStep(const G4ThreeVector& posIn,                              
+                          const G4ThreeVector& posOut,
+                                G4double hdid) const;
+   
+  private:
+
+    // INVARIANTS -- remain unchanged during tracking / integration 
+    // Parameters
+    G4double fMinimumStep;
+    G4bool   fVerbosity;
+
+    // State -- The core stepping algorithm
+    QTBorisScheme* boris;
+    
+    // STATE -- intermediate state (to avoid creation / churn )
+    G4double yIn[G4FieldTrack::ncompSVEC],
+             yMid[G4FieldTrack::ncompSVEC],
+             yOut[G4FieldTrack::ncompSVEC],
+             yError[G4FieldTrack::ncompSVEC];
+
+    G4double yCurrent[G4FieldTrack::ncompSVEC];
+
+    // - Unused 2022.11.03:   
+    // G4double derivs[2][6][G4FieldTrack::ncompSVEC];
+    // const G4int interval_sequence[2];
+   
+    // INVARIANTS -- Parameters for ensuring that one call has finite number of integration steps
+    static constexpr G4int    fMaxNoSteps = 300; 
+    static constexpr G4double fSmallestFraction= 1e-12; // To avoid FP underflow !  ( 1.e-6 for single prec)
+
+    static constexpr G4int    fIntegratorOrder= 2; //  2nd order method -- needed for error control
+    static constexpr G4double fSafetyFactor = 0.9; //
+
+    static constexpr G4double fMaxSteppingIncrease= 10.0; //  Increase no more than 10x   
+    static constexpr G4double fMaxSteppingDecrease= 0.1;  //  Reduce   no more than 10x
+    static constexpr G4double fPowerShrink = -1.0 / fIntegratorOrder;
+    static constexpr G4double fPowerGrow   = -1.0 / (1.0 + fIntegratorOrder);
+
+    static const G4double fErrorConstraintShrink;
+    static const G4double fErrorConstraintGrow;
+   
+    using ChordFinderDelegate = G4ChordFinderDelegate<QTBorisDriver>;
+};
+
+#include "QTBorisDriver.icc"
+
+#endif

--- a/include/QTBorisDriver.hh
+++ b/include/QTBorisDriver.hh
@@ -98,7 +98,8 @@ class QTBorisDriver : public G4VIntegrationDriver,
       ChordFinderDelegate::ResetStepEstimate();
     }
 
-    void OnComputeStep(const G4FieldTrack*) override {}
+  //  void OnComputeStep(const G4FieldTrack*) override {}
+  void OnComputeStep() override {}
 
     // 3. Does the method redo integrations when called to obtain values for
     //    internal, smaller intervals? (when needed to identify an intersection)

--- a/include/QTBorisDriver.icc
+++ b/include/QTBorisDriver.icc
@@ -1,0 +1,117 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// from G4BorisDriver inline methods implementation
+
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun
+// --------------------------------------------------------------------
+
+void QTBorisDriver::SetVerboseLevel(G4int level)
+{
+    fVerbosity = (level != 0);
+}
+
+G4int QTBorisDriver::GetVerboseLevel() const
+{
+    return static_cast<G4int>(fVerbosity);
+}
+
+G4double QTBorisDriver::ComputeNewStepSize( G4double /* errMaxNorm*/, G4double  hstepCurrent)
+{
+   return hstepCurrent;
+}
+
+const G4EquationOfMotion* QTBorisDriver::GetEquationOfMotion() const
+{
+   auto eq = boris->GetEquationOfMotion();
+   return eq;
+}
+
+G4EquationOfMotion* QTBorisDriver::GetEquationOfMotion()
+{
+   auto eq = boris->GetEquationOfMotion();
+   return eq;
+}
+
+#if 0
+// #ifdef G4USE_SET_EQUATION_OF_MOTION
+void QTBorisDriver::
+SetEquationOfMotion( G4EquationOfMotion* equation )
+{
+    boris->SetEquationOfMotion(equation);
+}
+#endif
+
+G4int QTBorisDriver::GetNumberOfVariables() const
+{
+    return boris->GetNumberOfVariables();
+}
+
+const G4MagIntegratorStepper*
+QTBorisDriver::GetStepper() const
+{
+    return nullptr;
+}
+
+G4MagIntegratorStepper*
+QTBorisDriver::GetStepper()
+{
+    return nullptr;
+}
+
+void QTBorisDriver::CheckStep(const G4ThreeVector& posIn,
+                              const G4ThreeVector& posOut,
+                              G4double hdid) const
+{
+   const G4double endPointDist = (posOut - posIn).mag();
+   if (endPointDist >= hdid * (1. + CLHEP::perMillion))
+   {
+      // ++fNoAccurateAdvanceBadSteps;
+// #ifdef G4DEBUG_FIELD
+      // Issue a warning only for gross differences -
+      // we understand how small difference occur.
+      if (endPointDist >= hdid * (1. + CLHEP::perThousand))
+      {
+         G4Exception("QTBorisDriver::CheckStep()",
+                     "GeomField1002", JustWarning,
+                     "endPointDist >= hdid!");
+      }
+      else
+      {
+         G4cerr << "QTBorisDriver::CheckStep: moved further than curve distance! "
+                << "  curve hdid= " << hdid << " endpoint dist= " << endPointDist
+                << "  ratio - 1 = " << (endPointDist - hdid) / hdid
+                << " ( > 1.0e-6 threshold to report ) "
+                << G4endl; 
+      }
+// #endif
+   }
+   else
+   {
+      // ++fNoAccurateAdvanceGoodSteps;
+   }
+}
+

--- a/include/QTBorisScheme.hh
+++ b/include/QTBorisScheme.hh
@@ -36,6 +36,7 @@
 #define QTBORIS_SCHEME_HH
 
 class G4EquationOfMotion;
+class QTEquationOfMotion;
 
 #include "G4Types.hh"
 
@@ -84,7 +85,8 @@ private:
   
 private:
   
-  G4EquationOfMotion* fEquation = nullptr;
+  G4EquationOfMotion* fEquation = nullptr; // general EoM
+  QTEquationOfMotion* pEqn      = nullptr; // our EoM
   G4int fnvar = 8;
   static constexpr G4double c_l = CLHEP::c_light/CLHEP::m*CLHEP::second; // SI unit
 };

--- a/include/QTBorisScheme.hh
+++ b/include/QTBorisScheme.hh
@@ -43,50 +43,50 @@ class G4EquationOfMotion;
 
 class QTBorisScheme
 {
-  public:
+public:
 
-    QTBorisScheme() = default;
-    QTBorisScheme( // G4EqMagElectricField
-       G4EquationOfMotion* equation,
-                        G4int nvar = 6);
-   ~QTBorisScheme() = default;
-
-    void DoStep( G4double restMass, G4double charge, const G4double yIn[], 
-                 G4double yOut[], G4double hstep) const;
-
-  protected:
-    // Used to implement the 'DoStep' method above
-    void UpdatePosition(const G4double restMass, const G4double charge, const G4double yIn[],
-                 G4double yOut[], G4double hstep) const;
-
-    void UpdateVelocity(const G4double restMass, const G4double charge, const G4double yIn[],
-                 G4double yOut[], G4double hstep) const;
-
-  public: 
-    // - Methods using the Boris Scheme Stepping to estimate integration error
-    void StepWithErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
-                               G4double yOut[], G4double yErr[]) const;
-      // Use two half-steps (comparing to a full step) to obtain output and error estimate
-
-   void StepWithMidAndErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
-                               G4double yMid[], G4double yOut[], G4double yErr[]) const;
-      // Same, and also return mid-point evaluation
-
-    // Auxiliary method
-    inline G4EquationOfMotion* GetEquationOfMotion();
-    // inline void SetEquationOfMotion(G4EquationOfMotion* equation);  // Un-needed, dangerous
-
-    inline G4int GetNumberOfVariables() const;
-   
-  private:
-
-    void copy(G4double dst[], const G4double src[]) const;
-
-  private:
-
-    G4EquationOfMotion* fEquation = nullptr;
-    G4int fnvar = 8;
-    static constexpr G4double c_l = CLHEP::c_light/CLHEP::m*CLHEP::second;
+  QTBorisScheme() = default;
+  QTBorisScheme( // G4EqMagElectricField
+		G4EquationOfMotion* equation,
+		G4int nvar = 6);
+  ~QTBorisScheme() = default;
+  
+  void DoStep( G4double restMass, G4double charge, const G4double yIn[], 
+	       G4double yOut[], G4double hstep) const;
+  
+protected:
+  // Used to implement the 'DoStep' method above
+  void UpdatePosition(const G4double restMass, const G4double charge, const G4double yIn[],
+		      G4double yOut[], G4double hstep) const;
+  
+  void UpdateVelocity(const G4double restMass, const G4double charge, const G4double yIn[],
+		      G4double yOut[], G4double hstep) const;
+  
+public: 
+  // - Methods using the Boris Scheme Stepping to estimate integration error
+  void StepWithErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
+			     G4double yOut[], G4double yErr[]) const;
+  // Use two half-steps (comparing to a full step) to obtain output and error estimate
+  
+  void StepWithMidAndErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
+				   G4double yMid[], G4double yOut[], G4double yErr[]) const;
+  // Same, and also return mid-point evaluation
+  
+  // Auxiliary method
+  inline G4EquationOfMotion* GetEquationOfMotion();
+  // inline void SetEquationOfMotion(G4EquationOfMotion* equation);  // Un-needed, dangerous
+  
+  inline G4int GetNumberOfVariables() const;
+  
+private:
+  
+  void copy(G4double dst[], const G4double src[]) const;
+  
+private:
+  
+  G4EquationOfMotion* fEquation = nullptr;
+  G4int fnvar = 8;
+  static constexpr G4double c_l = CLHEP::c_light/CLHEP::m*CLHEP::second; // SI unit
 };
 
 #include "QTBorisScheme.icc"

--- a/include/QTBorisScheme.hh
+++ b/include/QTBorisScheme.hh
@@ -1,0 +1,93 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// from G4BorisScheme
+//
+// Class description:
+//
+// Implementation of the Boris algorithm for advancing 
+// charged particles in an electromagnetic field.
+
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun
+// --------------------------------------------------------------------
+#ifndef QTBORIS_SCHEME_HH
+#define QTBORIS_SCHEME_HH
+
+class G4EquationOfMotion;
+
+#include "G4Types.hh"
+
+#include <CLHEP/Units/PhysicalConstants.h>
+
+class QTBorisScheme
+{
+  public:
+
+    QTBorisScheme() = default;
+    QTBorisScheme( // G4EqMagElectricField
+       G4EquationOfMotion* equation,
+                        G4int nvar = 6);
+   ~QTBorisScheme() = default;
+
+    void DoStep( G4double restMass, G4double charge, const G4double yIn[], 
+                 G4double yOut[], G4double hstep) const;
+
+  protected:
+    // Used to implement the 'DoStep' method above
+    void UpdatePosition(const G4double restMass, const G4double charge, const G4double yIn[],
+                 G4double yOut[], G4double hstep) const;
+
+    void UpdateVelocity(const G4double restMass, const G4double charge, const G4double yIn[],
+                 G4double yOut[], G4double hstep) const;
+
+  public: 
+    // - Methods using the Boris Scheme Stepping to estimate integration error
+    void StepWithErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
+                               G4double yOut[], G4double yErr[]) const;
+      // Use two half-steps (comparing to a full step) to obtain output and error estimate
+
+   void StepWithMidAndErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
+                               G4double yMid[], G4double yOut[], G4double yErr[]) const;
+      // Same, and also return mid-point evaluation
+
+    // Auxiliary method
+    inline G4EquationOfMotion* GetEquationOfMotion();
+    // inline void SetEquationOfMotion(G4EquationOfMotion* equation);  // Un-needed, dangerous
+
+    inline G4int GetNumberOfVariables() const;
+   
+  private:
+
+    void copy(G4double dst[], const G4double src[]) const;
+
+  private:
+
+    G4EquationOfMotion* fEquation = nullptr;
+    G4int fnvar = 8;
+    static constexpr G4double c_l = CLHEP::c_light/CLHEP::m*CLHEP::second;
+};
+
+#include "QTBorisScheme.icc"
+#endif

--- a/include/QTBorisScheme.icc
+++ b/include/QTBorisScheme.icc
@@ -1,0 +1,47 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// G4BorisScheme inline methods implementation
+//
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun
+// --------------------------------------------------------------------
+
+#if 0
+inline void QTBorisScheme::SetEquationOfMotion(G4EquationOfMotion* eq)
+{
+    fEquation = eq;
+}
+#endif
+
+inline G4EquationOfMotion* QTBorisScheme::GetEquationOfMotion()
+{
+    return fEquation;
+}
+
+inline G4int QTBorisScheme::GetNumberOfVariables() const
+{
+    return fnvar;
+}

--- a/include/QTEquationOfMotion.hh
+++ b/include/QTEquationOfMotion.hh
@@ -20,7 +20,7 @@ public:
 			     G4double mass);
 
   G4ThreeVector GetCachedFieldValue();
-  G4ThreeVector CalcRadiationAcceleration(G4ThreeVector, G4ThreeVector, G4ThreeVector);
+  G4ThreeVector CalcRadiationAcceleration(G4ThreeVector, G4ThreeVector);
   G4ThreeVector CalcOmegaGivenB(G4ThreeVector, G4ThreeVector);
   G4ThreeVector CalcAccGivenB(G4ThreeVector, G4ThreeVector);
 
@@ -30,8 +30,10 @@ private:
   G4double fCharge;
 
   // conversion in [kg] not working
-  static constexpr G4double m_e = 9.1093837e-31; // [electron mass in [kg]; needed only here
-  static constexpr G4double c_SI = c_light/(m/s); // explicit SI units
+  static constexpr G4double m_e     = 9.1093837e-31; // [electron mass in [kg]; needed only here
+  static constexpr G4double c_SI    = c_light/(m/s); // explicit SI units
+  static constexpr G4double eps0_SI = epsilon0/(farad/m); // explicit SI units
+  static constexpr G4double tau_SI  = e_SI*e_SI/(6.0*pi*eps0_SI*c_SI*c_SI*c_SI*m_e); // 6.26e-24 s
 
 };
 

--- a/include/QTEquationOfMotion.hh
+++ b/include/QTEquationOfMotion.hh
@@ -20,6 +20,7 @@ public:
 			     G4double mass);
 
   G4ThreeVector GetCachedFieldValue();
+  G4ThreeVector CalcRadiationAcceleration(G4ThreeVector, G4ThreeVector, G4ThreeVector);
   G4ThreeVector CalcOmegaGivenB(G4ThreeVector, G4ThreeVector);
   G4ThreeVector CalcAccGivenB(G4ThreeVector, G4ThreeVector);
 

--- a/include/QTMagneticFieldSetup.hh
+++ b/include/QTMagneticFieldSetup.hh
@@ -40,11 +40,11 @@
 
 class G4FieldManager;
 class G4ChordFinder;
-class QTEquationOfMotion;
 class G4MagIntegratorStepper;
 class G4MagInt_Driver;
-class G4BorisScheme;
-class G4BorisDriver;
+class QTBorisDriver;
+class QTBorisScheme;
+class QTEquationOfMotion;
 class QTFieldMessenger;
 
 /// A class for control of the Magnetic Field of the detector.
@@ -105,8 +105,8 @@ private:
  
   G4MagIntegratorStepper* fStepper;
   G4MagInt_Driver*        fIntgrDriver;
-  G4BorisScheme*          fBStepper;
-  G4BorisDriver*          fBDriver;
+  QTBorisScheme*          fBStepper;
+  QTBorisDriver*          fBDriver;
 
   //  G4int                   fStepperType;
 

--- a/src/QTBorisDriver.cc
+++ b/src/QTBorisDriver.cc
@@ -1,0 +1,333 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// from G4BorisDriver
+//
+// Class description:
+//
+//   G4BorisDriver is a driver class using the second order Boris 
+// method to integrate the equation of motion.
+// 
+//
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun 
+// --------------------------------------------------------------------
+#include <cassert>
+
+#include "QTBorisDriver.hh"
+
+#include "G4SystemOfUnits.hh"
+#include "G4LineSection.hh"
+#include "G4FieldUtils.hh"
+
+const G4double QTBorisDriver::fErrorConstraintShrink = std::pow(
+            fMaxSteppingDecrease / fSafetyFactor, 1. / fPowerShrink);
+
+const G4double QTBorisDriver::fErrorConstraintGrow = std::pow(
+            fMaxSteppingIncrease / fSafetyFactor, 1. / fPowerGrow);
+
+// --------------------------------------------------------------------------
+
+QTBorisDriver::
+QTBorisDriver( G4double hminimum, QTBorisScheme* Boris,
+               G4int numberOfComponents, G4bool verbosity )
+  : fMinimumStep(hminimum),
+    fVerbosity(verbosity),
+    boris(Boris)
+    // , interval_sequence{2,4}
+{    
+    assert(boris->GetNumberOfVariables() == numberOfComponents);
+    
+    if(boris->GetNumberOfVariables() != numberOfComponents)
+    {
+      std::ostringstream msg;
+      msg << "Disagreement in number of variables = "
+          << boris->GetNumberOfVariables()
+          << " vs no of components = " << numberOfComponents;
+      G4Exception("QTBorisDriver Constructor:",
+                  "GeomField1001", FatalException, msg);       
+    }
+
+}
+
+// --------------------------------------------------------------------------
+
+G4bool QTBorisDriver::AccurateAdvance( G4FieldTrack& track,
+                                       G4double hstep,
+                                       G4double  epsilon,
+                                       G4double  hinitial )
+{
+   // Specification: Driver with adaptive stepsize control.
+   // Integrate starting values at y_current over hstep x2 with (relative) accuracy 'eps'.
+   // On output 'track' is replaced by values at the end of the integration interval. 
+   
+   //  Ensure that hstep > 0
+   if(hstep == 0)
+   {
+      std::ostringstream message;
+      message << "Proposed step is zero; hstep = " << hstep << " !";
+      G4Exception("QTBorisDriver::AccurateAdvance()",
+                  "GeomField1001", JustWarning, message);
+      return true;
+   }
+   if(hstep < 0)
+   {
+      std::ostringstream message;
+      message << "Invalid run condition." << G4endl
+              << "Proposed step is negative; hstep = " << hstep << G4endl
+              << "Requested step cannot be negative! Aborting event.";
+      G4Exception("QTBorisDriver::AccurateAdvance()",
+                  "GeomField0003", EventMustBeAborted, message);
+      return false;
+   }
+
+   if( hinitial == 0.0 ) { hinitial = hstep; }   
+   if( hinitial < 0.0 ) { hinitial = std::fabs( hinitial ); }
+   // G4double htrial = std::min( hstep, hinitial );
+   G4double htrial = hstep;
+   // Decide first step size      
+
+   // G4int noOfSteps = h/hstep;
+   
+    // integration variables
+    //
+   track.DumpToArray(yCurrent);
+
+   const G4double restMass = track.GetRestMass();
+   const G4double charge = track.GetCharge()*e_SI;
+   const G4int    nvar= GetNumberOfVariables();
+   
+   // copy non-integration variables to out array
+   //
+   std::memcpy(yOut + nvar,
+               yCurrent + nvar,
+               sizeof(G4double)*(G4FieldTrack::ncompSVEC-nvar));
+   
+   G4double curveLength = track.GetCurveLength();  // starting value
+   const G4double endCurveLength = curveLength + hstep;
+
+   // -- Initial version: Did it in one step -- did not account for errors !!!
+   // G4FieldTrack yFldTrk(track);
+   // yFldTrk.LoadFromArray(yCurrent, G4FieldTrack::ncompSVEC);
+   // yFldTrk.SetCurveLength(curveLength);
+   // G4double dchord_step, dyerr_len;   
+   // QuickAdvance(yFldTrk, dydxCurrent, htrial, dchord_step, dyerr_len);
+
+   const G4double hThreshold = 
+        std::max(epsilon * hstep, fSmallestFraction * curveLength);
+
+   G4double htry= htrial;
+   
+   for (G4int nstp = 0; nstp < fMaxNoSteps; ++nstp)
+   {
+      G4double hdid= 0.0, hnext=0.0;
+        
+      OneGoodStep(yCurrent, curveLength, htry, epsilon, restMass, charge, hdid, hnext);
+      //*********
+
+      // Simple check: move (distance of displacement) is smaller than length along curve!
+      const G4ThreeVector StartPos = field_utils::makeVector(yCurrent, field_utils::Value3D::Position);      
+      const G4ThreeVector EndPos = field_utils::makeVector(yCurrent, field_utils::Value3D::Position);
+      CheckStep(EndPos, StartPos, hdid);
+      
+      // Check   1. for finish   and    2. *avoid* numerous small last steps
+      if (curveLength >= endCurveLength || htry < hThreshold)
+      {
+         break; 
+      }
+      
+      htry = std::max(hnext, fMinimumStep);
+      if (curveLength + htry > endCurveLength)
+      {
+         htry = endCurveLength - curveLength;
+      }
+   }
+
+   // upload new state   
+   track.LoadFromArray(yCurrent, G4FieldTrack::ncompSVEC);
+   track.SetCurveLength(curveLength);
+
+   return true;
+}
+
+// --------------------------------------------------------------------------
+
+void QTBorisDriver::OneGoodStep(G4double y[],           // InOut
+                                G4double& curveLength,  // InOut
+                                G4double  htry,
+                                G4double  epsilon_rel,
+                                G4double  restMass,
+                                G4double  charge,
+                                G4double& hdid,        // Out
+                                G4double& hnext)       // Out
+{
+    G4double error2 = DBL_MAX;
+    G4double yerr[G4FieldTrack::ncompSVEC], ytemp[G4FieldTrack::ncompSVEC];
+
+    G4double h = htry;
+
+    const G4int max_trials = 100; 
+
+    for (G4int iter = 0; iter < max_trials; ++iter)
+    {
+        boris->StepWithErrorEstimate(y, restMass, charge, h, ytemp, yerr);
+        
+        error2 = field_utils::relativeError2(y, yerr, std::max(h, fMinimumStep),
+                                             epsilon_rel);
+        if (error2 <= 1.0)
+        {
+            break; 
+        }
+
+        h = ShrinkStepSize2(h, error2);
+
+        G4double xnew = curveLength + h;
+        if(xnew == curveLength)
+        {
+            std::ostringstream message;
+            message << "Stepsize underflow in Stepper !" << G4endl
+                    << "- Step's start x=" << curveLength
+                    << " and end x= " << xnew 
+                    << " are equal !! " << G4endl
+                    << "  Due to step-size= " << h 
+                    << ". Note that input step was " << htry;
+            G4Exception("G4IntegrationDriver::OneGoodStep()",
+                        "GeomField1001", JustWarning, message);
+            break;
+        }
+    }
+
+    hnext = GrowStepSize2(h, error2);
+    curveLength += (hdid = h);
+
+    field_utils::copy(y, ytemp, GetNumberOfVariables());
+}
+
+// ===========------------------------------------------------------===========
+
+G4bool QTBorisDriver::
+QuickAdvance( G4FieldTrack& track, const G4double /*dydx*/[],
+              G4double hstep, G4double& missDist, G4double& dyerr)
+{
+    const auto nvar = boris->GetNumberOfVariables();
+
+    track.DumpToArray(yIn);
+    const G4double curveLength = track.GetCurveLength();
+
+    // call the boris method for step length hstep
+    G4double restMass = track.GetRestMass();
+    G4double charge = track.GetCharge()*e_SI;
+
+    // boris->DoStep(restMass, charge, yIn,  yMid, hstep*0.5);
+    // boris->DoStep(restMass, charge, yMid, yOut, hstep*0.5);  // Use mid-point !!
+    boris->StepWithMidAndErrorEstimate(yIn, restMass, charge, hstep,
+                                       yMid, yOut, yError);
+      // Same, and also return mid-point evaluation
+    
+    // How to calculate chord length??
+    const auto mid = field_utils::makeVector(yMid,
+                     field_utils::Value3D::Position);
+    const auto in  = field_utils::makeVector(yIn,
+                     field_utils::Value3D::Position);
+    const auto out = field_utils::makeVector(yOut,
+                     field_utils::Value3D::Position);
+
+    missDist = G4LineSection::Distline(mid, in, out);
+
+    dyerr = field_utils::absoluteError(yOut, yError, hstep);
+
+    // copy non-integrated variables to output array
+    //
+    std::memcpy(yOut + nvar, yIn + nvar,
+                sizeof(G4double) * (G4FieldTrack::ncompSVEC - nvar));
+
+    // set new state
+    //
+    track.LoadFromArray(yOut, G4FieldTrack::ncompSVEC);
+    track.SetCurveLength(curveLength +  hstep);
+
+    return true;
+}
+
+// --------------------------------------------------------------------------------
+
+void QTBorisDriver::
+GetDerivatives( const G4FieldTrack& yTrack, G4double dydx[]) const
+{
+   G4double  EBfieldValue[6];
+   GetDerivatives(yTrack, dydx, EBfieldValue);
+}
+
+// --------------------------------------------------------------------------------
+
+void QTBorisDriver::
+GetDerivatives( const G4FieldTrack& yTrack, G4double dydx[],
+                G4double EBfieldValue[]) const
+{
+   // G4Exception("QTBorisDriver::GetDerivatives()",
+   //             "GeomField0003", FatalException, "This method is not implemented.");
+   G4double ytemp[G4FieldTrack::ncompSVEC];
+   yTrack.DumpToArray(ytemp);
+   GetEquationOfMotion()->EvaluateRhsReturnB(ytemp, dydx, EBfieldValue);
+}
+
+// --------------------------------------------------------------------------------
+
+G4double QTBorisDriver::ShrinkStepSize2(G4double h, G4double error2) const
+{
+   if (error2 > fErrorConstraintShrink * fErrorConstraintShrink)
+   {
+      return fMaxSteppingDecrease * h;
+   }
+   return fSafetyFactor * h * std::pow(error2, 0.5 * fPowerShrink);
+}
+
+// --------------------------------------------------------------------------------
+
+G4double QTBorisDriver::GrowStepSize2(G4double h, G4double error2) const
+// Given the square of the relative error, 
+{
+    if (error2 < fErrorConstraintGrow * fErrorConstraintGrow)
+    {
+        return fMaxSteppingIncrease * h;
+    }
+    return fSafetyFactor * h * std::pow(error2, 0.5 * fPowerGrow);
+}
+
+// --------------------------------------------------------------------------------
+
+void QTBorisDriver::SetEquationOfMotion(G4EquationOfMotion* /*equation*/ )
+{
+   G4Exception("QTBorisDriver::SetEquationOfMotion()", "GeomField0003", FatalException,
+               "This method is not implemented. BorisDriver/Stepper should keep its equation");
+}
+
+// --------------------------------------------------------------------------------
+
+void
+QTBorisDriver::StreamInfo( std::ostream& os ) const
+{
+  os << "State of QTBorisDriver: " << std::endl;
+  os << "   Method is implemented, but gives no information. " << std::endl;
+}

--- a/src/QTBorisScheme.cc
+++ b/src/QTBorisScheme.cc
@@ -1,0 +1,190 @@
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// from G4BorisScheme implementation
+//
+// Author: Divyansh Tiwari, Google Summer of Code 2022
+// Supervision: John Apostolakis,Renee Fatemi, Soon Yung Jun
+// --------------------------------------------------------------------
+
+#include "G4FieldUtils.hh"
+#include "G4SystemOfUnits.hh"
+#include "globals.hh"
+#include "G4PhysicalConstants.hh"
+#include "G4EquationOfMotion.hh"
+
+#include "QTBorisScheme.hh"
+
+
+using namespace field_utils;
+
+QTBorisScheme::QTBorisScheme( G4EquationOfMotion* equation,
+                                        G4int nvar )
+  : fEquation(equation), fnvar(nvar)
+{
+  if (nvar <= 0)
+  {
+    G4Exception("QTBorisScheme::QTBorisScheme()",
+                "GeomField0002", FatalException,
+                "Invalid number of variables; must be greater than zero!");
+  }
+}
+
+void QTBorisScheme::DoStep(const G4double restMass,const G4double charge, const G4double yIn[], 
+                                 G4double yOut[], G4double hstep) const
+{
+  G4double yOut1Temp[G4FieldTrack::ncompSVEC];
+  G4double yOut2Temp[G4FieldTrack::ncompSVEC];
+  
+  // Used the scheme described in the following paper:
+  // https://www.research-collection.ethz.ch/bitstream/handle/20.500.11850/153167/eth-5175-01.pdf?sequence=1
+  UpdatePosition(restMass, charge,  yIn, yOut1Temp, hstep/2);
+  UpdateVelocity(restMass, charge, yOut1Temp, yOut2Temp, hstep);
+  UpdatePosition(restMass, charge, yOut2Temp, yOut, hstep/2);
+}
+
+void QTBorisScheme::UpdatePosition(const G4double restMass, const G4double /*charge*/, const G4double yIn[],
+                                   G4double yOut[], G4double hstep) const
+{
+    // Particle information
+    copy(yOut, yIn);
+    
+    // Obtaining velocity
+    G4ThreeVector momentum_vec =G4ThreeVector(yIn[3],yIn[4],yIn[5]);
+    G4double momentum_mag = momentum_vec.mag();
+    G4ThreeVector momentum_dir =(1.0/momentum_mag)*momentum_vec;
+
+    G4double velocity_mag = momentum_mag*(c_l)/(std::sqrt(sqr(momentum_mag) +sqr(restMass)));
+    G4ThreeVector velocity = momentum_dir*velocity_mag;
+
+    //Obtaining the time step from the length step
+
+    hstep /= velocity_mag*CLHEP::m;
+
+    // Updating the Position
+    for(G4int i = 0; i <3; i++ )
+    {
+      G4double pos = yIn[i]/CLHEP::m;
+      pos += hstep*velocity[i];
+      yOut[i] = pos*CLHEP::m;
+    }   
+}
+
+void QTBorisScheme::UpdateVelocity(const G4double restMass, const G4double charge, const G4double yIn[], 
+                                   G4double yOut[], G4double hstep) const
+{
+   //Particle information
+    G4ThreeVector momentum_vec =G4ThreeVector(yIn[3],yIn[4],yIn[5]);
+    G4double momentum_mag = momentum_vec.mag();
+    G4ThreeVector momentum_dir =(1.0/momentum_mag)*momentum_vec;
+
+    G4double gamma = std::sqrt(sqr(momentum_mag) + sqr(restMass))/restMass;  
+    
+    G4double mass = (restMass/c_squared)/CLHEP::kg;
+    
+    //Obtaining velocity
+   
+    G4double velocity_mag = momentum_mag*(c_l)/(std::sqrt(sqr(momentum_mag) +sqr(restMass)));
+    G4ThreeVector velocity = momentum_dir*velocity_mag;
+
+    ////Obtaining the time step from the length step
+    
+    hstep /= velocity_mag*CLHEP::m; 
+       
+    // Obtaining the field values
+    G4double dydx[G4FieldTrack::ncompSVEC];
+    G4double fieldValue[6] ={0,0,0,0,0,0};
+    fEquation->EvaluateRhsReturnB(yIn, dydx, fieldValue); // use getFieldValue(postime, fieldValue)
+   
+    //Initializing Vectors
+    G4ThreeVector B;
+    // G4ThreeVector E; // not used
+    copy(yOut, yIn);
+    for( G4int i = 0; i < 3; i++)
+    {
+      //        E[i] = fieldValue[i+3]/CLHEP::volt*CLHEP::meter;// FIXME - Check Units
+        B[i] = fieldValue[i]/CLHEP::tesla;   
+    }
+    
+    //Boris Algorithm
+    G4double qd = hstep*(charge/(2*mass*gamma));
+    G4ThreeVector h = qd*B;
+    G4ThreeVector u = velocity + qd*E; // half-time step acceleration here
+    G4double h_l = h[0]*h[0] + h[1]*h[1] + h[2]*h[2];
+    G4ThreeVector s_1 = (2*h)/(1 + h_l);
+    G4ThreeVector ud = u + (u + u.cross(h)).cross(s_1);
+    G4ThreeVector v_fi = ud +qd*E; // half-time step acceleration here
+    G4double v_mag = std::sqrt(v_fi.mag2());
+    G4ThreeVector v_dir = v_fi/v_mag;
+    G4double momen_mag = (restMass*v_mag)/(std::sqrt(c_l*c_l - v_mag*v_mag));
+    G4ThreeVector momen = momen_mag*v_dir;
+
+    // Storing the updated momentum
+    for(int i = 3; i < 6; i++)
+    {
+        yOut[i] = momen[i-3];   
+    }
+}
+
+// ----------------------------------------------------------------------------------
+
+void QTBorisScheme::copy(G4double dst[], const G4double src[]) const
+{
+  std::memcpy(dst, src, sizeof(G4double) * fnvar);
+}
+
+// ----------------------------------------------------------------------------------
+// - Methods using the Boris Scheme Stepping to estimate integration error
+// ----------------------------------------------------------------------------------
+void QTBorisScheme::
+StepWithErrorEstimate(const G4double yIn[], G4double restMass, G4double charge, G4double hstep,
+                      G4double yOut[], G4double yErr[]) const
+{
+   // Use two half-steps (comparing to a full step) to obtain output and error estimate
+   G4double yMid[G4FieldTrack::ncompSVEC];
+   StepWithMidAndErrorEstimate(yIn, restMass, charge, hstep, yMid, yOut, yErr);
+}
+
+// ----------------------------------------------------------------------------------
+
+void QTBorisScheme::
+StepWithMidAndErrorEstimate(const G4double yIn[],  G4double restMass, G4double charge, G4double hstep,
+                                  G4double yMid[], G4double yOut[],   G4double yErr[]
+   ) const
+{
+   G4double halfStep= 0.5*hstep;
+   G4double yOutAlt[G4FieldTrack::ncompSVEC];   
+
+   // In a single step
+   DoStep(restMass, charge, yIn,  yOutAlt, hstep );
+
+   // Same, and also return mid-point evaluation
+   DoStep(restMass, charge, yIn,  yMid, halfStep );
+   DoStep(restMass, charge, yMid, yOut, halfStep );
+
+   for( G4int i= 0; i<fnvar; i++ )
+   {
+      yErr[i] = yOutAlt[i] - yOut[i];
+   }
+}

--- a/src/QTEquationOfMotion.cc
+++ b/src/QTEquationOfMotion.cc
@@ -64,5 +64,6 @@ G4ThreeVector QTEquationOfMotion::CalcOmegaGivenB(G4ThreeVector Bfield, G4ThreeV
 G4ThreeVector QTEquationOfMotion::CalcAccGivenB(G4ThreeVector BField, G4ThreeVector beta)
 {
   G4ThreeVector omega = CalcOmegaGivenB(BField, beta);
-  return beta.cross(omega) * c_SI; // missing radiation acceleration term
+  G4ThreeVector rad_acceleration = CalcRadiationAcceleration(BField, beta);
+  return beta.cross(omega) * c_SI + rad_acceleration; // added radiation acceleration term
 }

--- a/src/QTEquationOfMotion.cc
+++ b/src/QTEquationOfMotion.cc
@@ -24,6 +24,11 @@ G4ThreeVector QTEquationOfMotion::GetCachedFieldValue()
   return G4ThreeVector(0.,0.,0.);
 }
 
+G4ThreeVector QTEquationOfMotion::CalcRadiationAcceleration(G4ThreeVector Bfield, G4ThreeVector pos, G4ThreeVector beta)
+{
+}
+
+
 G4ThreeVector QTEquationOfMotion::CalcOmegaGivenB(G4ThreeVector Bfield, G4ThreeVector beta)
 {
   // B must arrive in [Tesla]

--- a/src/QTEquationOfMotion.cc
+++ b/src/QTEquationOfMotion.cc
@@ -28,11 +28,11 @@ G4ThreeVector QTEquationOfMotion::CalcRadiationAcceleration(G4ThreeVector Bfield
 {
   // calculate acceleration from the radiation reaction force
   // form is from Ford & O'Connell equation in 3D
-  G4ThreeVector omega = CalcOmegaGivenB(BField, beta);
+  G4ThreeVector omega = CalcOmegaGivenB(Bfield, beta);
   G4double denom = 1.0+tau_SI*tau_SI*(omega.dot(omega));
 
   // target vector
-  G4ThreeVector acc;
+  G4ThreeVector acc; // default constructor sets components to 0.0
   acc[0] -= tau_SI*(omega[2]*omega[2]+omega[1]*omega[1])*beta[0]*c_SI;
   acc[0] += tau_SI*omega[0]*(omega[2]*beta[2]+omega[1]*beta[1])*c_SI;
 
@@ -61,9 +61,14 @@ G4ThreeVector QTEquationOfMotion::CalcOmegaGivenB(G4ThreeVector Bfield, G4ThreeV
     return (fCharge*e_SI) * Bfield / m_e / gamma_rel;
 }
 
-G4ThreeVector QTEquationOfMotion::CalcAccGivenB(G4ThreeVector BField, G4ThreeVector beta)
+G4ThreeVector QTEquationOfMotion::CalcAccGivenB(G4ThreeVector Bfield, G4ThreeVector beta)
 {
-  G4ThreeVector omega = CalcOmegaGivenB(BField, beta);
-  G4ThreeVector rad_acceleration = CalcRadiationAcceleration(BField, beta);
+  G4ThreeVector omega = CalcOmegaGivenB(Bfield, beta);
+  G4ThreeVector rad_acceleration = CalcRadiationAcceleration(Bfield, beta);
+  // G4cout << "Acc inputs: "
+  // 	 << " omega mag " << omega.mag() 
+  // 	 << " radacc = " << rad_acceleration.x() 
+  // 	 << ", " << rad_acceleration.y() << ", " << rad_acceleration.z() 
+  // 	 << G4endl;
   return beta.cross(omega) * c_SI + rad_acceleration; // added radiation acceleration term
 }

--- a/src/QTEquationOfMotion.cc
+++ b/src/QTEquationOfMotion.cc
@@ -24,8 +24,26 @@ G4ThreeVector QTEquationOfMotion::GetCachedFieldValue()
   return G4ThreeVector(0.,0.,0.);
 }
 
-G4ThreeVector QTEquationOfMotion::CalcRadiationAcceleration(G4ThreeVector Bfield, G4ThreeVector pos, G4ThreeVector beta)
+G4ThreeVector QTEquationOfMotion::CalcRadiationAcceleration(G4ThreeVector Bfield, G4ThreeVector beta)
 {
+  // calculate acceleration from the radiation reaction force
+  // form is from Ford & O'Connell equation in 3D
+  G4ThreeVector omega = CalcOmegaGivenB(BField, beta);
+  G4double denom = 1.0+tau_SI*tau_SI*(omega.dot(omega));
+
+  // target vector
+  G4ThreeVector acc;
+  acc[0] -= tau_SI*(omega[2]*omega[2]+omega[1]*omega[1])*beta[0]*c_SI;
+  acc[0] += tau_SI*omega[0]*(omega[2]*beta[2]+omega[1]*beta[1])*c_SI;
+
+  acc[1] -= tau_SI*(omega[2]*omega[2]+omega[0]*omega[0])*beta[1]*c_SI;
+  acc[1] += tau_SI*omega[1]*(omega[2]*beta[2]+omega[0]*beta[0])*c_SI;
+
+  acc[2] -= tau_SI*(omega[0]*omega[0]+omega[1]*omega[1])*beta[2]*c_SI;
+  acc[2] += tau_SI*omega[2]*(omega[0]*beta[0]+omega[1]*beta[1])*c_SI;
+
+  acc /= denom;
+  return acc;
 }
 
 

--- a/src/QTMagneticFieldSetup.cc
+++ b/src/QTMagneticFieldSetup.cc
@@ -45,9 +45,8 @@
 #include "G4MagIntegratorDriver.hh"
 #include "G4ChordFinder.hh"
 
-// #include "BorisStepper.hh"
-#include "G4BorisScheme.hh"
-#include "G4BorisDriver.hh"
+#include "QTBorisScheme.hh"
+#include "QTBorisDriver.hh"
 
 #include "G4PhysicalConstants.hh"
 #include "G4SystemOfUnits.hh"
@@ -128,9 +127,9 @@ void QTMagneticFieldSetup::SetUpBorisDriver()
   // set up Boris driver from Geant4.11, follows example field01
   G4cout << " F01FieldSetup::CreateAndSetupBorisDriver() called. " << G4endl;   
   G4cout << "   1. Creating Scheme (Stepper)."  << G4endl;
-  fBStepper = new G4BorisScheme(fEquation);
+  fBStepper = new QTBorisScheme(fEquation);
   G4cout << "   2. Creating Driver."  << G4endl;
-  fBDriver  = new G4BorisDriver(fMinStep, fBStepper);
+  fBDriver  = new QTBorisDriver(fMinStep, fBStepper);
 
   G4cout  << "  3. Creating ChordFinder."  << G4endl;
   fChordFinder = new G4ChordFinder( fBDriver );


### PR DESCRIPTION
This tries to add the required radiation reaction acceleration to the transport of the electron. So far, we only use the Lorentz force, encoded in the G4 Boris ODE solver for a magnetic field. We have to modify the G4Boris solver implementation, no changes to interfaces, thankfully.
The equation of motion carries the calculation since it is known to the solver and delivers the total acceleration as convenience function for the antenna response too.
The solver is used in the magnetic field setup.
The skeleton is in the first commit. Implementation to follow, not ready yet.