### PR TITLE
Add gps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ and run in the build directory.
 
 ### Status update
 
-Compiles and runs at this stage for the test0.mac test case. Most required physics features are missing. They can now be implemented, each by separate branch, ideally.
+Compiles and runs at this stage for the test0/1/2.mac test cases. Most required physics features have been implemented.
+Next is the most flexible primary particle event generator, the GPS. Pre-defined primary particle event generators remain, i.e a test generator (default energy, at origin, 90 degree pitch angle, aka in x-direction), the electron gun generator and the Tritium beta decay generator. The GPS then allows creating a primary electron conveniently by macro, very flexible configurations are possible.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,8 @@ and run in the build directory.
 
 ### Status update
 
-Compiles and runs at this stage for the test0/1/2.mac test cases. Most required physics features have been implemented.
-Next is the most flexible primary particle event generator, the GPS. Pre-defined primary particle event generators remain, i.e a test generator (default energy, at origin, 90 degree pitch angle, aka in x-direction), the electron gun generator and the Tritium beta decay generator. The GPS then allows creating a primary electron conveniently by macro, very flexible configurations are possible.
+Compiles and runs at this stage for the test0/1/2/3.mac test cases. Most required physics features have been implemented.
+The flexible primary particle event generator, the GPS, was implemented. Pre-defined primary particle event generators 
+remain, i.e a test generator 
+(default energy, at origin, 90 degree pitch angle, aka in x-direction), the electron gun generator and the Tritium beta decay generator. The GPS allows creating a primary electron conveniently by macro, very flexible configurations are possible.
+A run timer is the latest update, printing to screen at the end of run.

--- a/include/QTPrimaryGeneratorAction.hh
+++ b/include/QTPrimaryGeneratorAction.hh
@@ -11,6 +11,7 @@
 #include "globals.hh"
 
 class G4ParticleGun;
+class G4GeneralParticleSource;
 class G4Event;
 
 
@@ -31,11 +32,14 @@ private:
 
   void DefineCommands();
 
-  G4ParticleGun*      fParticleGun;
+  G4ParticleGun*           fParticleGun;
+  G4GeneralParticleSource* fParticleGPS;
+
   G4GenericMessenger* fMessenger;
 
   G4bool              fTestElectron;
-  G4bool              fGunType;
+  G4bool              fEGun;
+  G4bool              fTritium;
   // electron gun parameter
   G4double            fMean;
   G4double            fStdev;

--- a/include/QTRunAction.hh
+++ b/include/QTRunAction.hh
@@ -5,6 +5,7 @@
 #include "globals.hh"
 
 class G4Run;
+class G4Timer;
 class QTOutputManager;
 
 /// Run action class
@@ -22,6 +23,7 @@ public:
 
 private:
   QTOutputManager* fOutput = nullptr; // outsource output file storage
+  G4Timer*         fTimer  = nullptr;
 
 };
 

--- a/src/QTEventAction.cc
+++ b/src/QTEventAction.cc
@@ -66,7 +66,7 @@ void QTEventAction::EndOfEventAction(const G4Event* event)
 
   // fill Hits output from SD
   G4int GnofHits = GasHC->entries();
-  G4cout << "PRINT>>> number of hits: " << GnofHits << G4endl;
+  //  G4cout << "PRINT>>> number of hits: " << GnofHits << G4endl;
   // Gas detector
   for ( G4int i=0; i<GnofHits; i++ ) 
   {
@@ -118,7 +118,7 @@ void QTEventAction::EndOfEventAction(const G4Event* event)
   G4int                  n_trajectories =
     (trajectoryContainer == nullptr) ? 0 : trajectoryContainer->entries();
 
-  G4cout << "PRINT>>> number of trajectories: " << n_trajectories << G4endl;
+  //  G4cout << "PRINT>>> number of trajectories: " << n_trajectories << G4endl;
   
   if(n_trajectories > 0) {
     for(auto* entry : *(trajectoryContainer->GetVector())) {  // vector<G4VTrajectory*>*

--- a/src/QTMagneticFieldSetup.cc
+++ b/src/QTMagneticFieldSetup.cc
@@ -149,7 +149,7 @@ QTMagneticFieldSetup::~QTMagneticFieldSetup()
 void QTMagneticFieldSetup::SetUpBorisDriver()
 {
   // set up Boris driver from Geant4.11, follows example field01
-  G4cout << " QTFieldSetup::CreateAndSetupBorisDriver() called. " << G4endl;   
+  //  G4cout << " QTFieldSetup::CreateAndSetupBorisDriver() called. " << G4endl;   
   //  G4cout << "   1. Creating Scheme (Stepper)."  << G4endl;
   fBStepper = new QTBorisScheme(fEquation);
   //  G4cout << "   2. Creating Driver."  << G4endl;

--- a/src/QTOutputManager.cc
+++ b/src/QTOutputManager.cc
@@ -27,7 +27,7 @@ void QTOutputManager::Book()
   analysisManager = G4AnalysisManager::Instance();
 
   if ( ! fFactoryOn ) {
-    analysisManager->SetVerboseLevel(1);
+    analysisManager->SetVerboseLevel(0);
     analysisManager->SetNtupleMerging(true);
 
     // Create directory

--- a/src/QTRunAction.cc
+++ b/src/QTRunAction.cc
@@ -3,6 +3,7 @@
 
 #include "G4Run.hh"
 #include "G4RunManager.hh"
+#include "G4Timer.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4UnitsTable.hh"
 
@@ -11,6 +12,7 @@
 QTRunAction::QTRunAction(QTOutputManager* out)
 : G4UserRunAction()
 , fOutput(out)
+, fTimer(0)
 {
 }
 
@@ -19,11 +21,23 @@ QTRunAction::~QTRunAction() = default;
 void QTRunAction::BeginOfRunAction(const G4Run* /*run*/)
 {
   fOutput->Book(); // set up output
+
+  if (isMaster) {
+    fTimer = new G4Timer();
+    fTimer->Start();
+  }
 }
 
 void QTRunAction::EndOfRunAction(const G4Run* aRun)
 {
+  if (isMaster) {
+    fTimer->Stop();
+    G4cout << "Master thread time: " << *fTimer << G4endl;
+    delete fTimer;
+  }
+
   G4int nofEvents = aRun->GetNumberOfEvent();
   G4cout << "End of Run: number of events to file is " << nofEvents << G4endl;
   fOutput->Save(); // write and close
+
 }

--- a/test/test3.mac
+++ b/test/test3.mac
@@ -1,0 +1,22 @@
+# minimal test macro
+# verbose
+/run/verbose 0
+/tracking/verbose 2
+
+# apply limit to transport before run init
+/QT/transport/maxtime 0.5 ns
+/QT/transport/maxstep 0.5 mm
+
+# run init
+/run/initialize
+
+# set field Z value
+/field/setFieldZ 1.0 tesla
+/field/uniformB
+/field/update
+
+# test GPS default, no command
+/gps/verbose 2
+
+# start
+/run/beamOn 1


### PR DESCRIPTION
add the general particle source as event generator; keep the specialized sources: test, electron gun and most importantly, the tritium beta decay generator. Use macro switches (bools) to pick a source. None chosen means choosing the GPS - use macro commands to change the default settings (default energy from origin in x-axis direction = 90 degree pitch angle, single electron).