### PR TITLE
Bugfix: scoring hits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ and run in the build directory.
 
 ### Status update
 
+Version v0.4-beta: repaired hit scoring bug. The standard filtering for deposited energy misses a large number of
+Coulomb scatter hits. Two new hit filters were imlemented in QTGasSD: first on process name, score all
+non-transportation process steps; second, require a change of momentum pitch angle (theta to z-axis) of more than
+1.e-3 radians or 0.057 degrees. Likewise, the unnecessary scoring from the maximum time limit process, i.e. at the
+final step without any scattering process involved, has been removed.
+
+Observation was that no hits were produced even in artificially increased Tritum gas densities. Inspection of tracking
+log output shows that scattering does occur as expected but the predominant scattering outcome at relevant energies
+is dominated by momentum changes rather than deposited energy. The momentum vector changes direction post-step and
+that leads quite often to electrons leaving the trap hence is significant and should be stored as a hit.
+
 The tagged version v0.3-beta is feature complete and tested. It remains a pre-release version since important
 input data like a realistic geometry and corresponding field map are missing. Examples provided only permit
 tests of functionality.

--- a/src/QTEventAction.cc
+++ b/src/QTEventAction.cc
@@ -66,7 +66,7 @@ void QTEventAction::EndOfEventAction(const G4Event* event)
 
   // fill Hits output from SD
   G4int GnofHits = GasHC->entries();
-  //  G4cout << "PRINT>>> number of hits: " << GnofHits << G4endl;
+  G4cout << "EVENT>>> number of hits: " << GnofHits << G4endl;
   // Gas detector
   for ( G4int i=0; i<GnofHits; i++ ) 
   {

--- a/src/QTGasSD.cc
+++ b/src/QTGasSD.cc
@@ -4,6 +4,7 @@
 #include "G4Step.hh"
 #include "G4ThreeVector.hh"
 #include "G4SDManager.hh"
+#include "G4VProcess.hh"
 #include "G4ios.hh"
 
 QTGasSD::QTGasSD(const G4String& name,
@@ -34,19 +35,25 @@ void QTGasSD::Initialize(G4HCofThisEvent* hce)
 G4bool QTGasSD::ProcessHits(G4Step* aStep, 
                             G4TouchableHistory*)
 {  
-  // energy deposit
-  G4double edep = aStep->GetTotalEnergyDeposit();
+  // process filter
+  auto* vprocess = aStep->GetPostStepPoint()->GetProcessDefinedStep();
+  if (vprocess->GetProcessName()=="Transportation") return false;
+
+  // pitch angle change condition < 0.057 degrees
   G4ThreeVector premom  = aStep->GetPreStepPoint()->GetMomentumDirection();
   G4ThreeVector postmom = aStep->GetPostStepPoint()->GetMomentumDirection();
-
-  if (edep / CLHEP::keV <= 1.e-6) return false;
-  else if ((premom.cross(postmom)).mag() <= 1.e-8) return false; // parallel = not interested
-
+  if (fabs(premom.theta()-postmom.theta()) < 1.0e-3) return false;
+  
+  G4double postkine = aStep->GetPostStepPoint()->GetKineticEnergy();
+  if (postkine/CLHEP::eV < 1.0) {
+    G4cout << ">>>SD >>> no post step kinetic energy left, not stored" << G4endl;
+    return false; // stopped electron by max time cut, not interested
+  }
   QTGasHit* newHit = new QTGasHit();
   G4ThreeVector preloc = aStep->GetPreStepPoint()->GetPosition();
 
   newHit->SetTrackID(aStep->GetTrack()->GetTrackID());
-  newHit->SetEdep(edep);
+  newHit->SetEdep(aStep->GetTotalEnergyDeposit());
   newHit->SetTime(aStep->GetTrack()->GetGlobalTime());
   newHit->SetPreKine(aStep->GetPreStepPoint()->GetKineticEnergy());
   newHit->SetPostKine(aStep->GetPostStepPoint()->GetKineticEnergy());


### PR DESCRIPTION
The filter settings in QTGasSD for scoring hits were not right - no hit scoring despite ramping up gas density. Coulomb scattering does take place but predominantly results in electron momentum changes in direction, especially the pitch angle changes are significant since they lead to electrons potentially leaving the trap after scattering.
New filtering conditions have been implemented to score such hits.