### PR TITLE
Remove version specific Geant4 references from CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       # Build Package
       - name: Build
         run: |
-          source /geant4-v11.2.2-install/bin/geant4.sh
+          source /geant4-install/bin/geant4.sh
           mkdir build && cd build
           cmake ..
           make
@@ -43,7 +43,7 @@ jobs:
       # Build Package
       - name: Run
         run: |
-          source /geant4-v11.2.2-install/bin/geant4.sh
+          source /geant4-install/bin/geant4.sh
           source /cern_root/bin/thisroot.sh
           cd build
           ./qtnmSim -m ../test/test0.mac -g ../test/test.gdml


### PR DESCRIPTION
Allows the docker image to be updated to the latest version without requiring QTNMSim CI files to be modified.