### PR TITLE
Tom/multi scattering

### DIFF
--- a/.github/workflows/BuildandTest.yml
+++ b/.github/workflows/BuildandTest.yml
@@ -57,7 +57,11 @@ jobs:
           # Run Test0, inelastic cross section
           ./TestEm0 -m TestEm0.in -o HydrogenInelasticCrossSection.root -p InelasticScatteringList
           python3 test0.py --input HydrogenInelasticCrossSection.root --output HydrogenInelasticCrossSection.png --yscale linear --reference_results=shah1987.txt
-      
+
+          # Run Test0, combined cross section
+          ./TestEm0 -m TestEm0.in -o HydrogenFullCrossSection.root -p MultipleScatteringList
+          python3 test0.py --input HydrogenFullCrossSection.root --output HydrogenFullCrossSection.png --yscale linear
+
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/BuildandTest.yml
+++ b/.github/workflows/BuildandTest.yml
@@ -60,7 +60,7 @@ jobs:
 
           # Run Test0, combined cross section
           ./TestEm0 -m TestEm0.in -o HydrogenFullCrossSection.root -p MultipleScatteringList
-          python3 test0.py --input HydrogenFullCrossSection.root --output HydrogenFullCrossSection.png --yscale linear
+          python3 test0.py --input HydrogenFullCrossSection.root --output HydrogenFullCrossSection.png
 
       - name: Upload results
         uses: actions/upload-artifact@v4

--- a/include/QTNMeImpactIonisation.hh
+++ b/include/QTNMeImpactIonisation.hh
@@ -62,7 +62,6 @@
 #include "globals.hh"
 #include <map>
 
-class G4eDPWAElasticDCS;
 class G4ParticleChangeForGamma;
 class G4ParticleDefinition;
 class G4DataVector;
@@ -99,10 +98,6 @@ public:
   G4double MinPrimaryEnergy(const G4Material*, const G4ParticleDefinition*,
                             G4double) override { return 10.0*CLHEP::eV; }
 
-  void     SetTheDCS(G4eDPWAElasticDCS* theDCS) { fTheDCS = theDCS; }
-
-  G4eDPWAElasticDCS* GetTheDCS() { return fTheDCS; }
-
   std::map<int, std::vector<G4double>> GetBindingEnergies() { return binding_energies; }
   void SetBindingEnergies(std::map<int, std::vector<G4double>> be) { binding_energies = be; }
 
@@ -112,8 +107,6 @@ private:
   std::vector<G4double>     get_ionisation_energies(G4int Z) { return binding_energies[Z]; };
   G4double                  mbell_gr(G4double U, G4double J);
   G4double                  mbell_f_ion(G4int z_eff, G4double U, G4int Z, G4double m_lambda);
-  // the object that provides cross sections and polar angle of scattering
-  G4eDPWAElasticDCS*         fTheDCS;
   // particle change
   G4ParticleChangeForGamma*  fParticleChange;
   // Energy space for secondary CDF

--- a/src/QTNMPhysicsList.cc
+++ b/src/QTNMPhysicsList.cc
@@ -2,6 +2,7 @@
 
 #include "G4SystemOfUnits.hh"
 #include "G4ParticleDefinition.hh"
+#include "G4EmMultiModel.hh"
 #include "G4LossTableManager.hh"
 #include "G4EmParameters.hh"
 #include "G4EmBuilder.hh"
@@ -56,7 +57,7 @@ G4_DECLARE_PHYSCONSTR_FACTORY(QTNMPhysicsList);
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-QTNMPhysicsList::QTNMPhysicsList(G4int ver, 
+QTNMPhysicsList::QTNMPhysicsList(G4int ver,
                                  const G4String&)
   : G4VPhysicsConstructor("QTNMPhysics"), verbose(ver)
 {
@@ -152,13 +153,17 @@ void QTNMPhysicsList::ConstructProcess()
 
   // e-
   particle = G4Electron::Electron();
- 
-  // single scattering
-  G4CoulombScattering* ss = new G4CoulombScattering();
-  ss->AddEmModel(0, new G4eDPWACoulombScatteringModel(false, false, 0.0));
 
+  // Coulomb Scattering
+  G4CoulombScattering* ss = new G4CoulombScattering();
+  G4EmMultiModel* mm = new G4EmMultiModel("CoulombSSModels");
+  // Elastic Scattering
+  G4eDPWACoulombScatteringModel* es = new G4eDPWACoulombScatteringModel(false, false, 0.0);
+  es->SetPolarAngleLimit(0.0); // No mixed model
+  mm->AddModel(es);
   // Impact Ionisation
-  ss->AddEmModel(0, new QTNMeImpactIonisation());
+  mm->AddModel(new QTNMeImpactIonisation());
+  ss->AddEmModel(0, mm);
 
   // bremsstrahlung
   G4eBremsstrahlung* brem = new G4eBremsstrahlung();
@@ -210,4 +215,3 @@ void QTNMPhysicsList::ConstructProcess()
   G4EmBuilder::ConstructCharged(hmsc, pnuc);
 
 }
-

--- a/src/QTNMeImpactIonisation.cc
+++ b/src/QTNMeImpactIonisation.cc
@@ -46,7 +46,6 @@
 #include <iterator>
 #include <algorithm>
 
-#include "G4eDPWAElasticDCS.hh"
 #include "G4ParticleChangeForGamma.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4DataVector.hh"
@@ -67,7 +66,6 @@
 
 QTNMeImpactIonisation::QTNMeImpactIonisation()
 : G4VEmModel("eDPWACoulombScattering"),
-  fTheDCS(nullptr),
   fParticleChange(nullptr)
 {
   SetLowEnergyLimit (  0.0*CLHEP::eV);  // ekin = 10 eV   is used if (E< 10  eV)
@@ -77,9 +75,6 @@ QTNMeImpactIonisation::QTNMeImpactIonisation()
 
 QTNMeImpactIonisation::~QTNMeImpactIonisation()
 {
-  if (IsMaster()) {
-    delete fTheDCS;
-  }
 }
 
 
@@ -88,9 +83,6 @@ void QTNMeImpactIonisation::Initialise(const G4ParticleDefinition* pdef,
 {
   fParticleChange = GetParticleChangeForGamma();
   if(IsMaster()) {
-    // clean the G4eDPWAElasticDCS object if any
-    delete fTheDCS;
-    fTheDCS = new G4eDPWAElasticDCS(pdef==G4Electron::Electron(), false);
     // init only for the elements that are used in the geometry
     G4ProductionCutsTable* theCpTable = G4ProductionCutsTable::GetProductionCutsTable();
     G4int numOfCouples = (G4int)theCpTable->GetTableSize();
@@ -100,7 +92,6 @@ void QTNMeImpactIonisation::Initialise(const G4ParticleDefinition* pdef,
       std::size_t numOfElem = mat->GetNumberOfElements();
       for (std::size_t ie = 0; ie < numOfElem; ++ie) {
 	G4int Z = (*elV)[ie]->GetZasInt();
-        fTheDCS->InitialiseForZ(Z);
 	// Load the ionisation energies
 	load_ionisation_energies(Z);
       }
@@ -115,7 +106,6 @@ void QTNMeImpactIonisation::InitialiseLocal(const G4ParticleDefinition*,
                                                     G4VEmModel* masterModel)
 {
   SetElementSelectors(masterModel->GetElementSelectors());
-  SetTheDCS(static_cast<QTNMeImpactIonisation*>(masterModel)->GetTheDCS());
   SetBindingEnergies(static_cast<QTNMeImpactIonisation*>(masterModel)->GetBindingEnergies());
 }
 

--- a/src/QTNMeImpactIonisation.cc
+++ b/src/QTNMeImpactIonisation.cc
@@ -65,7 +65,7 @@
 #include "G4AnalysisManager.hh"
 
 QTNMeImpactIonisation::QTNMeImpactIonisation()
-: G4VEmModel("eDPWACoulombScattering"),
+: G4VEmModel("eImpactIonisation"),
   fParticleChange(nullptr)
 {
   SetLowEnergyLimit (  0.0*CLHEP::eV);  // ekin = 10 eV   is used if (E< 10  eV)

--- a/test/Test0/include/MultipleScatteringList.hh
+++ b/test/Test0/include/MultipleScatteringList.hh
@@ -1,0 +1,34 @@
+// QTNMPysicsList
+//
+//----------------------------------------------------------------------------
+//
+// This class provides construction of EM physics for the QTNM project
+// following closely the G4EmStandardPhysics_option4 list
+// of standard and low-energy packages and set of
+// the most adavced options allowing precise simulation at low
+// and intermediate energies.
+// Main difference: removal of electron multiple scattering with
+//                  single electron scattering to account for
+//                  very low target material density.
+//
+
+#ifndef MultipleScatteringList_h
+#define MultipleScatteringList_h 1
+
+#include "G4VPhysicsConstructor.hh"
+#include "globals.hh"
+
+class MultipleScatteringList : public G4VPhysicsConstructor {
+public:
+  explicit MultipleScatteringList(G4int ver = 1, const G4String &name = "");
+
+  ~MultipleScatteringList() override;
+
+  void ConstructParticle() override;
+  void ConstructProcess() override;
+
+private:
+  G4int verbose;
+};
+
+#endif

--- a/test/Test0/src/MultipleScattering.cc
+++ b/test/Test0/src/MultipleScattering.cc
@@ -1,0 +1,118 @@
+#include "MultipleScatteringList.hh"
+
+#include "G4EmBuilder.hh"
+#include "G4EmParameters.hh"
+#include "G4EmMultiModel.hh"
+#include "G4LossTableManager.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4SystemOfUnits.hh"
+
+// photons
+#include "G4BetheHeitler5DModel.hh"
+#include "G4ComptonScattering.hh"
+#include "G4GammaConversion.hh"
+#include "G4KleinNishinaModel.hh"
+#include "G4LivermorePhotoElectricModel.hh"
+#include "G4LowEPComptonModel.hh"
+#include "G4PEEffectFluoModel.hh"
+#include "G4PhotoElectricEffect.hh"
+#include "G4RayleighScattering.hh"
+
+// e+-
+#include "G4CoulombScattering.hh"
+#include "QTNMeImpactIonisation.hh"
+#include "G4Generator2BN.hh"
+#include "G4Generator2BS.hh"
+#include "G4LivermoreIonisationModel.hh"
+#include "G4PenelopeIonisationModel.hh"
+#include "G4SeltzerBergerModel.hh"
+#include "G4UniversalFluctuation.hh"
+#include "G4eBremsstrahlung.hh"
+#include "G4eDPWACoulombScatteringModel.hh"
+#include "G4eIonisation.hh"
+#include "G4ePairProduction.hh"
+
+#include "G4eplusAnnihilation.hh"
+
+// ions
+#include "G4IonParametrisedLossModel.hh"
+#include "G4NuclearStopping.hh"
+#include "G4hIonisation.hh"
+#include "G4hMultipleScattering.hh"
+#include "G4ionIonisation.hh"
+
+#include "G4Electron.hh"
+#include "G4Gamma.hh"
+#include "G4GenericIon.hh"
+#include "G4Positron.hh"
+
+#include "G4BuilderType.hh"
+#include "G4GammaGeneralProcess.hh"
+#include "G4PhysicsListHelper.hh"
+
+// factory
+#include "G4PhysicsConstructorFactory.hh"
+//
+G4_DECLARE_PHYSCONSTR_FACTORY(MultipleScatteringList);
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+MultipleScatteringList::MultipleScatteringList(G4int ver, const G4String &)
+    : G4VPhysicsConstructor("MultipleScattering"), verbose(ver) {
+  G4EmParameters *param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(verbose);
+  param->SetMinEnergy(100 * CLHEP::eV);
+  param->SetLowestElectronEnergy(100 * CLHEP::eV);
+  param->SetNumberOfBinsPerDecade(20);
+  param->ActivateAngularGeneratorForIonisation(true);
+  param->SetStepFunction(0.2, 10 * CLHEP::um);
+  param->SetStepFunctionMuHad(0.1, 50 * CLHEP::um);
+  param->SetStepFunctionLightIons(0.1, 20 * CLHEP::um);
+  param->SetStepFunctionIons(0.1, 1 * CLHEP::um);
+  param->SetMuHadLateralDisplacement(true);
+  param->SetFluo(true);
+  param->SetMscThetaLimit(0.0);
+  param->SetAuger(true);
+  param->SetAugerCascade(true);
+  param->SetPixe(true);
+  param->SetUseICRU90Data(true);
+  param->SetMaxNIELEnergy(1 * CLHEP::MeV);
+  SetPhysicsType(bElectromagnetic);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+MultipleScatteringList::~MultipleScatteringList() = default;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void MultipleScatteringList::ConstructParticle() {
+  // minimal set of particles for EM physics
+  G4EmBuilder::ConstructMinimalEmSet();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void MultipleScatteringList::ConstructProcess() {
+  if (verbose > 1) {
+    G4cout << "### " << GetPhysicsName() << " Construct Processes " << G4endl;
+  }
+  G4EmBuilder::PrepareEMPhysics();
+
+  G4PhysicsListHelper *ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // e-
+  G4ParticleDefinition *particle = G4Electron::Electron();
+
+  // Coulomb Scattering
+  G4CoulombScattering* ss = new G4CoulombScattering();
+  G4EmMultiModel* mm = new G4EmMultiModel("CoulombSSModels");
+  // Elastic Scattering
+  mm->AddModel(new G4eDPWACoulombScatteringModel(false, false, 0.0));
+  // Impact Ionisation
+  mm->AddModel(new QTNMeImpactIonisation());
+  ss->AddEmModel(0, mm);
+
+  ph->RegisterProcess(ss, particle);
+}

--- a/test/Test0/src/MultipleScattering.cc
+++ b/test/Test0/src/MultipleScattering.cc
@@ -109,7 +109,9 @@ void MultipleScatteringList::ConstructProcess() {
   G4CoulombScattering* ss = new G4CoulombScattering();
   G4EmMultiModel* mm = new G4EmMultiModel("CoulombSSModels");
   // Elastic Scattering
-  mm->AddModel(new G4eDPWACoulombScatteringModel(false, false, 0.0));
+  G4eDPWACoulombScatteringModel* es = new G4eDPWACoulombScatteringModel(false, false, 0.0);
+  es->SetPolarAngleLimit(0.0); // No mixed model
+  mm->AddModel(es);
   // Impact Ionisation
   mm->AddModel(new QTNMeImpactIonisation());
   ss->AddEmModel(0, mm);


### PR DESCRIPTION
@yramachers This appears functional from my testing. Test0 produces a combined cross section which appears reasonable. Sampling of secondary samples in main executable appears to function.

 - Combine elastic and inelastic scattering into a single multi-model.
 - Explicitly set polar angle limit for elastic scattering to zero to unambiguously force it into non-mixed model mode.
 - Add multi-model scattering to Test0.
 - Clear up impact ionisation by deleting unused DCS object.