### PR TITLE
Traj filter

### DIFF
--- a/src/QTTrajectory.cc
+++ b/src/QTTrajectory.cc
@@ -61,7 +61,7 @@ void QTTrajectory::AppendStep(const G4Step* aStep)
 	aStep->GetTrack()->GetMaterial()->GetName()=="matT")) return;
 
   // stop trajectory below threshold vertex kinetic energy
-  if (GetInitialEnergy() <= 1.5 / keV) return;
+  if (GetInitialEnergy()/keV <= 1.5) return;
 
   // take care of units [time] [distance]
   // observed steps with equal time values -> prevent; time must be larger than previous

--- a/src/QTTrajectory.cc
+++ b/src/QTTrajectory.cc
@@ -60,6 +60,9 @@ void QTTrajectory::AppendStep(const G4Step* aStep)
   if (!(aStep->GetTrack()->GetMaterial()->GetName()=="G4_Galactic" ||
 	aStep->GetTrack()->GetMaterial()->GetName()=="matT")) return;
 
+  // stop trajectory below threshold vertex kinetic energy
+  if (GetInitialEnergy() <= 1.5 / keV) return;
+
   // take care of units [time] [distance]
   // observed steps with equal time values -> prevent; time must be larger than previous
   // appear to be boundary steps


### PR DESCRIPTION
Inserted single if clause to filter trajectories for too low energy electrons: prevent writing trajectory data for such electrons due to undersampling.