### PR TITLE
Add primary generator feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Collect requirements in issue tracker and start populating code base.
 At Warwick, SCRTP, use cvmfs as the easiest environment setup (with bash):
 
 ```
-source /cvmfs/sft.cern.ch/lcg/views/LCG_105/x86_64-el9-gcc13-opt/setup.sh
+source /cvmfs/sft.cern.ch/lcg/views/LCG_109/x86_64-el9-gcc15-opt/setup.sh
 ```
 
 Anyone using CentOS7 can source the following environment:
@@ -18,7 +18,7 @@ Anyone using CentOS7 can source the following environment:
 source /cvmfs/sft.cern.ch/lcg/views/LCG_105/x86_64-centos7-gcc12-opt/setup.sh
 ```
 
-which sets up Geant4 11.2 and GCC13(12) on a CentOS9(7) background. ROOT 6.30 and cmake 3.26 will also be available. Just create a 'build' directory, then 
+which sets up Geant4 11.4(2) and GCC15(12) on a CentOS9(7) background. ROOT 6.38(0) and cmake 3.30(26) will also be available. Just create a 'build' directory, then 
 
 ```
 cd build; cmake ..; make

--- a/include/QTPrimaryGeneratorAction.hh
+++ b/include/QTPrimaryGeneratorAction.hh
@@ -40,6 +40,7 @@ private:
   G4bool              fTestElectron;
   G4bool              fEGun;
   G4bool              fTritium;
+  G4bool              fBespokeTritium;
   // electron gun parameter
   G4double            fMean;
   G4double            fStdev;
@@ -50,7 +51,10 @@ private:
   G4double            fSterilemass;
   G4double            fSterilemixing;
   G4double            fLowerBoundTritium;
-
+  G4double            fQminusThis;
+  G4double            fAngleLow;
+  G4double            fAngleHigh;
+  
   std::ranlux24       generator;
   std::random_device  rd; // for random seeds
 };

--- a/src/QTPrimaryGeneratorAction.cc
+++ b/src/QTPrimaryGeneratorAction.cc
@@ -37,7 +37,7 @@ QTPrimaryGeneratorAction::QTPrimaryGeneratorAction()
 , fSterilemass(0.0)
 , fSterilemixing(0.0)
 , fLowerBoundTritium(1.5) // Lower bound for Tritium decay energy
-, fQminusThis(0.0)  // no energy lower bound [keV] from Q-value
+, fQminusThis(0.2)  // no energy lower bound [keV] from Q-value
 , fAngleLow(0.0)  // pitch angle [deg] lower bound, default unused
 , fAngleHigh(89.0)  // pitch angle [deg] high bound, default unused
 {
@@ -174,6 +174,12 @@ void QTPrimaryGeneratorAction::DefineCommands()
   typeCmd.SetParameterName("ttt", true);
   typeCmd.SetDefaultValue("false");
 
+  // tritium type command
+  auto& tritCmd = fMessenger->DeclareProperty("BespokeTritium", fBespokeTritium,
+					      "Boolean true=use TBetaDecay with specs on energy and pitch angle.");
+  tritCmd.SetParameterName("tttt", true);
+  tritCmd.SetDefaultValue("false");
+
   // energy command
   auto& energyCmd = fMessenger->DeclareProperty("gunEnergy", fMean,
                                                "Mean Gun energy [keV].");
@@ -228,5 +234,26 @@ void QTPrimaryGeneratorAction::DefineCommands()
   lboundCmd.SetParameterName("lbound", true);
   lboundCmd.SetRange("lbound>=0.");
   lboundCmd.SetDefaultValue("1.5");
+
+  // Beta decay energy lower bound distance from Q-value
+  auto& lqmtCmd = fMessenger->DeclareProperty("eQminusThis", fQminusThis,
+						"Low energy distance from Q-value for Tritium decay [keV].");
+  lqmtCmd.SetParameterName("lqmt", true);
+  lqmtCmd.SetRange("lqmt>=0.");
+  lqmtCmd.SetDefaultValue("0.2");
+
+  // Beta decay pitch angle lower bound
+  auto& angleLowCmd = fMessenger->DeclareProperty("mintheta", fAngleLow,
+						"Lower bound pitch angle for Tritium decay [deg].");
+  angleLowCmd.SetParameterName("alow", true);
+  angleLowCmd.SetRange("alow>=0.");
+  angleLowCmd.SetDefaultValue("0.0");
+
+  // Beta decay pitch angle lower bound
+  auto& angleHighCmd = fMessenger->DeclareProperty("maxtheta", fAngleHigh,
+						"Higher bound pitch angle for Tritium decay [deg].");
+  angleHighCmd.SetParameterName("ahigh", true);
+  angleHighCmd.SetRange("ahigh>=0.");
+  angleHighCmd.SetDefaultValue("90.0");
 
 }

--- a/src/QTPrimaryGeneratorAction.cc
+++ b/src/QTPrimaryGeneratorAction.cc
@@ -39,7 +39,7 @@ QTPrimaryGeneratorAction::QTPrimaryGeneratorAction()
 , fLowerBoundTritium(1.5) // Lower bound for Tritium decay energy
 , fQminusThis(0.2)  // no energy lower bound [keV] from Q-value
 , fAngleLow(0.0)  // pitch angle [deg] lower bound, default unused
-, fAngleHigh(89.0)  // pitch angle [deg] high bound, default unused
+, fAngleHigh(90.0)  // pitch angle [deg] high bound, default unused
 {
   generator.seed(rd()); // using random seed
 
@@ -128,8 +128,18 @@ void QTPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     G4double zpos            = -atomZHalfLength + 2.0*atomZHalfLength*G4UniformRand();
     fParticleGun->SetParticlePosition(G4ThreeVector(rad*std::cos(phi)*mm, rad*std::sin(phi)*mm, zpos*mm));
     if (fBespokeTritium) { // direction within pitch angle interval
+      /// sanity checks
       if (fAngleHigh>90.0) fAngleHigh = 90.0; // don't permit > 90 deg pitch
-      G4double radians  = CLHEP::RandFlat::shoot(fAngleLow, fAngleHigh) * CLHEP::pi / 180.0; // exclusive upper limit
+      if (fAngleHigh<fAngleLow) {  // swap
+	G4double dummy = fAngleHigh;
+	fAngleHigh = fAngleLow;
+	fAngleLow = dummy;
+      }
+      G4double radians;
+      if (fAngleLow != fAngleHigh)
+	radians  = CLHEP::RandFlat::shoot(fAngleLow, fAngleHigh) * CLHEP::pi / 180.0; // exclusive upper limit
+      else
+	radians  = fAngleLow * CLHEP::pi / 180.0; // fixed pitch angle, not random
       G4double zz  = std::cos(radians); // cos theta
       G4double rho = std::sqrt(1-zz*zz); // sin theta
       G4double azi = CLHEP::twopi * G4UniformRand();

--- a/src/QTPrimaryGeneratorAction.cc
+++ b/src/QTPrimaryGeneratorAction.cc
@@ -29,6 +29,7 @@ QTPrimaryGeneratorAction::QTPrimaryGeneratorAction()
 , fStdev(5.e-4) // for E-gun
 , fSpot(0.5)    // for E-gun
 , fTritium(false) // switch to Trtium beta decay generator
+, fBespokeTritium(false) // no Tritium source specs
 , fEGun(false) // calibration: true=electron gun
 , fTestElectron(false)  // 90 degree electron for testing, override other guns
 , fOrder(true)   // neutrino hierarchie: true=normal
@@ -36,6 +37,9 @@ QTPrimaryGeneratorAction::QTPrimaryGeneratorAction()
 , fSterilemass(0.0)
 , fSterilemixing(0.0)
 , fLowerBoundTritium(1.5) // Lower bound for Tritium decay energy
+, fQminusThis(0.0)  // no energy lower bound [keV] from Q-value
+, fAngleLow(0.0)  // pitch angle [deg] lower bound, default unused
+, fAngleHigh(89.0)  // pitch angle [deg] high bound, default unused
 {
   generator.seed(rd()); // using random seed
 
@@ -105,9 +109,13 @@ void QTPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
 
     // distribution parameter
     int nw = 10000; // nw - number of bins
-    double ubound = TBeta::endAt(fNumass, 1); // max energy
+    double ubound = TBeta::endAt(fNumass, 1); // max energy, new Q-value minus nu mass
 
     // create distribution
+    if (fBespokeTritium) {
+      nw = 1000; // smaller energy interval, fewer bins
+      fLowerBoundTritium = ubound - fQminusThis;  // keep to [keV]
+    }
     pld_type ed(nw, fLowerBoundTritium, ubound, betaGenerator(fOrder, fNumass,
 							      fSterilemass, fSterilemixing));
 
@@ -119,7 +127,17 @@ void QTPrimaryGeneratorAction::GeneratePrimaries(G4Event* event)
     G4double rad             = G4UniformRand() * atomRadius;
     G4double zpos            = -atomZHalfLength + 2.0*atomZHalfLength*G4UniformRand();
     fParticleGun->SetParticlePosition(G4ThreeVector(rad*std::cos(phi)*mm, rad*std::sin(phi)*mm, zpos*mm));
-    fParticleGun->SetParticleMomentumDirection(G4RandomDirection()); // 4 pi solid angle
+    if (fBespokeTritium) { // direction within pitch angle interval
+      if (fAngleHigh>90.0) fAngleHigh = 90.0; // don't permit > 90 deg pitch
+      G4double radians  = CLHEP::RandFlat::shoot(fAngleLow, fAngleHigh) * CLHEP::pi / 180.0; // exclusive upper limit
+      G4double zz  = std::cos(radians); // cos theta
+      G4double rho = std::sqrt(1-zz*zz); // sin theta
+      G4double azi = CLHEP::twopi * G4UniformRand();
+      G4ThreeVector dir(rho*std::cos(azi), rho*std::sin(azi), zz);
+      fParticleGun->SetParticleMomentumDirection(dir); // random angle in interval
+    }
+    else
+      fParticleGun->SetParticleMomentumDirection(G4RandomDirection()); // 4 pi solid angle
 
     // Beta decay random energy [keV]
     G4double en = ed(generator); // this is with std random


### PR DESCRIPTION
Add features to Tritium generator: 
min and max pitch angle to z-axis and 
an energy distance value to the Q-value to create energy sampling interval relative to Q-value rather than an absolute lower bound.
Commands only take effect with the switch BespokeTritium set to true.

Commands in macro following /QT/generator/XXX appear to work with dummy macro.
